### PR TITLE
feat: add DCH_SAMPLE_SEED for reproducible DCH abstract sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ This configuration file contains various settings for different job types. Below
 - `iterations`: Number of iterations for processing (e.g., `3`).
 - `DCH_MIN_SAMPLING_FRACTION`: Minimum sampling fraction for DCH (e.g., `0.06`).
 - `DCH_SAMPLE_SIZE`: Sample size for DCH (e.g., `50`).
+- `DCH_SAMPLE_SEED`: Integer seed for DCH abstract sampling, or `null` for unseeded
+  (default). When set, each iteration draws a reproducible sample — iterations still
+  differ from one another, but re-running the same config redraws iteration 1..N
+  identically. Useful for holding the sample fixed while varying something else
+  (model, prompt, censor year). Note that reproducibility is conditional on the
+  abstract pool being unchanged: if PubMed results or relevance-filter labels shift,
+  the same seed yields a different sample. The `Pool fingerprint:` INFO log line
+  identifies that case.
 - `TRITON_MAX_WORKERS`: Concurrent streaming inference workers for Triton (e.g., `10`).
 
 ## HTCONDOR

--- a/config_template.json
+++ b/config_template.json
@@ -25,6 +25,7 @@
         "iterations": 3,
         "DCH_MIN_SAMPLING_FRACTION": 0.06,
         "DCH_SAMPLE_SIZE": 50,
+        "DCH_SAMPLE_SEED": null,
         "TRITON_MAX_WORKERS": 10
     },
     "HTCONDOR": {

--- a/skimgpt/relevance_helper.py
+++ b/skimgpt/relevance_helper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import ast
+import hashlib
 import logging
 import os
 import random
@@ -249,20 +250,60 @@ def _normalize_fractions(
     return n1, n2
 
 
-def _sample_entries(entries: list, count: int) -> list:
-    """Randomly sample *count* items from *entries* (returns [] when count is 0)."""
+def _sample_entries(entries: list, count: int, rng=None) -> list:
+    """Randomly sample *count* items from *entries* (returns [] when count is 0).
+
+    Args:
+        entries: Pool to sample from.
+        count: Number of items to draw.
+        rng: Source of randomness.  Defaults to the ``random`` module (unseeded);
+            pass a ``random.Random`` instance for reproducible draws.
+    """
+    rng = rng or random
     if count > 0:
-        return random.sample(entries, count)
+        return rng.sample(entries, count)
     return []
 
 
-def sample_consolidated_abstracts(v1, v2, config: Config):
+def _dch_rng(config: Config, iteration_number: int):
+    """Return a seeded RNG for DCH sampling, or None when no seed is configured.
+
+    The seed is composed with the iteration index rather than added to it, so
+    iterations of one run draw different samples (which is the point of running
+    them) while any given iteration is reproducible across runs.  String
+    composition also keeps ``seed=1, iteration=2`` distinct from
+    ``seed=2, iteration=1``, which integer addition would collide.
+
+    A fresh ``Random`` instance per iteration is required, not optional:
+    iterations run concurrently in a thread pool (see ``run_iterations``), so
+    seeding the shared ``random`` module would race.
+    """
+    seed = config.global_settings.get("DCH_SAMPLE_SEED")
+    if seed is None:
+        return None
+    return random.Random(f"{seed}:{iteration_number}")
+
+
+def _pool_fingerprint(pmids: list) -> str:
+    """Short digest of an ordered PMID list, for diagnosing pool drift.
+
+    A seed only reproduces a sample given the same pool, and the pool depends on
+    PubMed results and relevance-filter labels.  Logging this makes "same seed,
+    different sample" identifiable as a changed pool rather than a broken seed.
+    """
+    joined = ",".join(str(pmid) for pmid in pmids)
+    return hashlib.sha256(joined.encode()).hexdigest()[:8]
+
+
+def sample_consolidated_abstracts(v1, v2, config: Config, rng=None):
     """Sample from two abstract collections; return consolidated text, sampled count, total deduped count.
 
     Args:
         v1: First collection of abstracts (list or single string or empty).
         v2: Second collection of abstracts (list or single string or empty).
         config: Global configuration providing sampling parameters.
+        rng: Source of randomness for the draw.  Defaults to unseeded sampling;
+            callers pass the per-iteration RNG from :func:`_dch_rng`.
 
     Returns:
         A tuple of (consolidated_abstracts: str, expected_count: int, total_relevant_abstracts: int)
@@ -285,6 +326,10 @@ def sample_consolidated_abstracts(v1, v2, config: Config):
     logger.info(f"  Candidate 1 PMIDs in pool: {pool_pmids1[:20]}{'...' if len(pool_pmids1) > 20 else ''}")
     logger.info(f"Sampling pool: Candidate 2 has {total2} deduplicated abstracts")
     logger.info(f"  Candidate 2 PMIDs in pool: {pool_pmids2[:20]}{'...' if len(pool_pmids2) > 20 else ''}")
+    logger.info(
+        f"Pool fingerprint: c1={total1}/{_pool_fingerprint(pool_pmids1)} "
+        f"c2={total2}/{_pool_fingerprint(pool_pmids2)}"
+    )
 
     logger.debug(f"entities_in_candidate1: {total1}")
     logger.debug(f"entities_in_candidate2: {total2}")
@@ -295,8 +340,8 @@ def sample_consolidated_abstracts(v1, v2, config: Config):
 
     n1, n2 = _normalize_fractions(total1, total2, min_floor, target_total)
 
-    sampled1 = _sample_entries(list1, n1)
-    sampled2 = _sample_entries(list2, n2)
+    sampled1 = _sample_entries(list1, n1, rng)
+    sampled2 = _sample_entries(list2, n2, rng)
 
     sampled_pmids1 = [extract_pmid(abstract) for abstract in sampled1]
     sampled_pmids2 = [extract_pmid(abstract) for abstract in sampled2]
@@ -367,7 +412,14 @@ def process_results(
         logger.info(f"DCH Sampling: Candidate 1 has {len(v1)} relevant abstracts")
         logger.info(f"DCH Sampling: Candidate 2 has {len(v2)} relevant abstracts")
 
-        consolidated_abstracts, expected_count, total_relevant_abstracts = sample_consolidated_abstracts(v1, v2, config)
+        rng = _dch_rng(config, iteration_number)
+        if rng is not None:
+            logger.info(
+                f"DCH sampling seed: {config.global_settings.get('DCH_SAMPLE_SEED')} "
+                f"(iteration {iteration_number})"
+            )
+
+        consolidated_abstracts, expected_count, total_relevant_abstracts = sample_consolidated_abstracts(v1, v2, config, rng)
 
         dch_row = {
             "hypothesis1": hyp1,

--- a/skimgpt/utils.py
+++ b/skimgpt/utils.py
@@ -445,7 +445,8 @@ class Config:
         # Validate configuration settings
         self._validate_job_settings()
         self._validate_relevance_filter_settings()
-        
+        self._validate_dch_sample_seed()
+
     def _validate_job_settings(self) -> None:
         """Validate job-specific settings for conflicts"""
         # Check for mutually exclusive settings in km_with_gpt
@@ -460,6 +461,24 @@ class Config:
                     "compares exactly 2 B terms against each A term. Please set one to false."
                 )
     
+    def _validate_dch_sample_seed(self) -> None:
+        """Validate DCH_SAMPLE_SEED, which must be an integer or null.
+
+        Checked at config load rather than at sampling time: sampling happens
+        after PubMed fetching and relevance filtering, so a malformed seed would
+        otherwise surface only once a run has already spent that time and those
+        tokens.
+        """
+        seed = self.global_settings.get("DCH_SAMPLE_SEED")
+        if seed is None:
+            return
+        if isinstance(seed, bool) or not isinstance(seed, int):
+            raise ValueError(
+                f"Configuration error: 'DCH_SAMPLE_SEED' must be an integer or null, "
+                f"got {type(seed).__name__} ({seed!r}). Omit it (or set null) for "
+                f"unseeded sampling."
+            )
+
     def _validate_relevance_filter_settings(self) -> None:
         """Validate required relevance filter settings for Triton inference"""
         required_params = {

--- a/tests/test_dch_sample_seed.py
+++ b/tests/test_dch_sample_seed.py
@@ -1,0 +1,227 @@
+"""DCH sampling reproducibility — locks in the DCH_SAMPLE_SEED contract.
+
+Seeded sampling fails invisibly: without these tests, an edit that drops the
+`rng` argument anywhere along the chain leaves sampling working perfectly, just
+no longer reproducible, and nothing downstream complains. The per-iteration
+derivation is equally load-bearing — collapsing it to a single seed would make
+every iteration draw the same sample, quietly turning an N-iteration variance
+estimate into N copies of one draw.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from skimgpt.relevance_helper import (
+    _dch_rng,
+    _pool_fingerprint,
+    _sample_entries,
+    sample_consolidated_abstracts,
+)
+from skimgpt.utils import extract_pmid
+
+DELIMITER = "===END OF ABSTRACT==="
+
+
+def _pool(prefix: str, count: int) -> list[str]:
+    """Build a pool of distinguishable abstract entries with parseable PMIDs."""
+    return [
+        f"Title {prefix}{i}. Abstract body {prefix}{i}. PMID: {prefix}{i:04d}{DELIMITER}"
+        for i in range(count)
+    ]
+
+
+def _config(seed=None, sample_size=10, min_fraction=0.06):
+    return SimpleNamespace(
+        global_settings={
+            "DCH_SAMPLE_SEED": seed,
+            "DCH_SAMPLE_SIZE": sample_size,
+            "DCH_MIN_SAMPLING_FRACTION": min_fraction,
+        }
+    )
+
+
+def _sampled_pmids(v1, v2, config, rng):
+    consolidated, _, _ = sample_consolidated_abstracts(v1, v2, config, rng)
+    return [extract_pmid(entry) for entry in consolidated.split(DELIMITER) if entry.strip()]
+
+
+# --- seeded reproducibility ---------------------------------------------------
+
+
+def test_same_seed_same_iteration_reproduces_sample():
+    v1, v2 = _pool("1", 200), _pool("2", 80)
+    config = _config(seed=1234)
+
+    first = _sampled_pmids(v1, v2, config, _dch_rng(config, 1))
+    second = _sampled_pmids(v1, v2, config, _dch_rng(config, 1))
+
+    assert first == second
+    assert len(first) == 10
+
+
+def test_iterations_draw_different_samples():
+    """The whole point of iterations — a shared seed must not collapse them."""
+    v1, v2 = _pool("1", 200), _pool("2", 80)
+    config = _config(seed=1234)
+
+    iter1 = _sampled_pmids(v1, v2, config, _dch_rng(config, 1))
+    iter2 = _sampled_pmids(v1, v2, config, _dch_rng(config, 2))
+
+    assert iter1 != iter2
+
+
+def test_different_seeds_draw_different_samples():
+    v1, v2 = _pool("1", 200), _pool("2", 80)
+
+    seed_a = _config(seed=1)
+    seed_b = _config(seed=2)
+
+    assert _sampled_pmids(v1, v2, seed_a, _dch_rng(seed_a, 1)) != _sampled_pmids(
+        v1, v2, seed_b, _dch_rng(seed_b, 1)
+    )
+
+
+def test_cross_seed_iteration_pairs_do_not_collide():
+    """(seed=1, iter=2) must differ from (seed=2, iter=1).
+
+    Integer addition would make these identical, silently sharing draws between
+    runs that are meant to be independent.
+    """
+    v1, v2 = _pool("1", 200), _pool("2", 80)
+
+    seed_a = _config(seed=1)
+    seed_b = _config(seed=2)
+
+    assert _sampled_pmids(v1, v2, seed_a, _dch_rng(seed_a, 2)) != _sampled_pmids(
+        v1, v2, seed_b, _dch_rng(seed_b, 1)
+    )
+
+
+def test_seeded_sampling_is_independent_of_global_random_state():
+    """Iterations run concurrently, so the draw must not depend on shared state."""
+    import random
+
+    v1, v2 = _pool("1", 200), _pool("2", 80)
+    config = _config(seed=99)
+
+    random.seed(0)
+    first = _sampled_pmids(v1, v2, config, _dch_rng(config, 1))
+    random.seed(12345)
+    [random.random() for _ in range(50)]
+    second = _sampled_pmids(v1, v2, config, _dch_rng(config, 1))
+
+    assert first == second
+
+
+# --- unseeded default --------------------------------------------------------
+
+
+def test_no_seed_means_no_rng():
+    assert _dch_rng(_config(seed=None), 1) is None
+
+
+def test_sample_entries_falls_back_to_module_random():
+    pool = _pool("1", 100)
+    drawn = _sample_entries(pool, 5, None)
+
+    assert len(drawn) == 5
+    assert all(entry in pool for entry in drawn)
+
+
+def test_unseeded_sampling_still_returns_the_target_size():
+    v1, v2 = _pool("1", 200), _pool("2", 80)
+    config = _config(seed=None)
+
+    consolidated, expected_count, total = sample_consolidated_abstracts(
+        v1, v2, config, _dch_rng(config, 1)
+    )
+
+    assert expected_count == 10
+    assert total == 280
+    assert consolidated
+
+
+# --- edges -------------------------------------------------------------------
+
+
+def test_zero_count_returns_empty_without_touching_rng():
+    """count == 0 must not consume RNG draws, or iteration streams would shift."""
+    assert _sample_entries(_pool("1", 10), 0, _dch_rng(_config(seed=7), 1)) == []
+
+
+def test_non_iterated_run_is_seeded_too():
+    """iteration_number == 0 (no iterations configured) still gets a stable draw."""
+    v1, v2 = _pool("1", 200), _pool("2", 80)
+    config = _config(seed=1234)
+
+    first = _sampled_pmids(v1, v2, config, _dch_rng(config, 0))
+    second = _sampled_pmids(v1, v2, config, _dch_rng(config, 0))
+
+    assert first == second
+
+
+def test_seed_zero_is_honored_not_treated_as_unset():
+    config = _config(seed=0)
+    assert _dch_rng(config, 1) is not None
+
+
+def test_pool_smaller_than_sample_size_is_exhausted_deterministically():
+    v1, v2 = _pool("1", 3), _pool("2", 2)
+    config = _config(seed=1234, sample_size=50)
+
+    first = _sampled_pmids(v1, v2, config, _dch_rng(config, 1))
+    second = _sampled_pmids(v1, v2, config, _dch_rng(config, 1))
+
+    assert first == second
+    assert sorted(first) == sorted(
+        [extract_pmid(entry) for entry in v1 + v2]
+    )
+
+
+# --- pool fingerprint --------------------------------------------------------
+
+
+def test_fingerprint_is_stable_and_order_sensitive():
+    pmids = ["111", "222", "333"]
+
+    assert _pool_fingerprint(pmids) == _pool_fingerprint(list(pmids))
+    assert _pool_fingerprint(pmids) != _pool_fingerprint(list(reversed(pmids)))
+    assert _pool_fingerprint(pmids) != _pool_fingerprint(pmids + ["444"])
+    assert len(_pool_fingerprint(pmids)) == 8
+
+
+def test_fingerprint_handles_empty_pool():
+    assert len(_pool_fingerprint([])) == 8
+
+
+# --- config validation -------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_seed", ["abc", 1.5, [1], {"a": 1}, True])
+def test_config_rejects_non_integer_seed(bad_seed):
+    from skimgpt.utils import Config
+
+    config = Config.__new__(Config)
+    config.global_settings = {"DCH_SAMPLE_SEED": bad_seed}
+
+    with pytest.raises(ValueError, match="DCH_SAMPLE_SEED"):
+        config._validate_dch_sample_seed()
+
+
+@pytest.mark.parametrize("good_seed", [None, 0, 1, 1234, -5])
+def test_config_accepts_integer_or_null_seed(good_seed):
+    from skimgpt.utils import Config
+
+    config = Config.__new__(Config)
+    config.global_settings = {"DCH_SAMPLE_SEED": good_seed}
+
+    config._validate_dch_sample_seed()
+
+
+def test_config_accepts_missing_seed_key():
+    from skimgpt.utils import Config
+
+    config = Config.__new__(Config)
+    config.global_settings = {}
+
+    config._validate_dch_sample_seed()


### PR DESCRIPTION
## Problem

DCH abstract sampling drew from the unseeded `random` module, so there was no way to hold the sample fixed while varying something else — model, prompt, censor year. Any comparison across runs confounded the change under test with a fresh random draw.

## What this adds

An optional `DCH_SAMPLE_SEED` in `GLOBAL_SETTINGS`. **Unset (the default) leaves behavior exactly as before** — no existing config changes meaning.

| Aspect | Behavior |
|---|---|
| Semantics | Same config reproduces iteration 1..N; iterations still differ from each other |
| Derivation | `random.Random(f"{seed}:{iteration_number}")` |
| Threading | Local `Random` instance injected down the call chain |
| Provenance | INFO log of effective seed + ordered-pool PMID digest |
| Override | Config-only — travels to CHTC jobs with the config |

## Three decisions worth reviewing

**Per-iteration derivation, not one seed per run.** Iterations exist to measure sampling variance. A single seed shared across them would make all N draws identical, silently turning an N-iteration variance estimate into N copies of one draw. The seed is composed with the iteration index instead.

**Composed as a string, not added.** `seed + iteration` makes `(seed=1, iter=2)` and `(seed=2, iter=1)` collide, so two runs meant to be independent would share draws across offset iterations. String composition avoids that and handles `iteration_number=0` (non-iterated runs) for free. Locked in by `test_cross_seed_iteration_pairs_do_not_collide`.

**A local `Random` instance, not `random.seed()`.** Iterations run concurrently in a thread pool (`run_iterations`, parallelism ≤5), so seeding the shared module RNG would race and defeat the seed nondeterministically. `_sample_entries` takes an `rng` defaulting to the `random` module, which shares the `.sample` signature.

## Known limitation, by design

A seed reproduces the sample **only given the same pool**, and the pool depends on PubMed results and Triton relevance-filter labels. If either shifts, the same seed yields a different sample. Rather than pretend otherwise, the run now logs a digest of the ordered pool PMIDs:

```
INFO - Pool fingerprint: c1=1337/9f3a1b2c c2=504/71de04aa
INFO - DCH sampling seed: 1234 (iteration 2)
```

That makes "same seed, different sample" identifiable as a changed pool rather than a broken seed. Documented in the README entry.

## Changes

- `skimgpt/relevance_helper.py` — `_dch_rng`, `_pool_fingerprint`; `rng` threaded through `sample_consolidated_abstracts` → `_sample_entries`; seed/fingerprint logging
- `skimgpt/utils.py` — `_validate_dch_sample_seed`, failing at config load rather than after a run has already spent PubMed and filtering time
- `config_template.json` — `"DCH_SAMPLE_SEED": null`
- `README.md` — key documented beside `DCH_SAMPLE_SIZE`, including the pool caveat
- `tests/test_dch_sample_seed.py` — 25 tests

## Testing

`pytest tests/` — 49 passed (24 pre-existing, 25 new). Covers seeded reproducibility, iteration divergence, cross-seed non-collision, independence from global `random` state, unseeded fallback, `seed=0` not being read as unset, `count=0` not consuming draws, pool-exhaustion, and the config validation matrix.

Not covered by tests: the one wiring line in `process_results` that builds the RNG, and no live DCH job was run against a real config.

## Out of scope

`hyp_stats.perm_test` (`skimgpt/visualization/hyp_stats.py:356`) uses unseeded `np.random` for its 10,000-permutation test — a real reproducibility hole, but in the post-hoc CLI path, not the DCH job path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)