### PR TITLE
test: characterize DCH sample allocation, simplify share renormalization

### DIFF
--- a/skimgpt/relevance_helper.py
+++ b/skimgpt/relevance_helper.py
@@ -207,14 +207,14 @@ def _normalize_fractions(
     if total2 > 0:
         s2 = max(s2, min_floor)
 
-    if s1 == 0 and s2 > 0:
-        s2 = 1.0
-    elif s2 == 0 and s1 > 0:
-        s1 = 1.0
-    else:
-        sum_s = s1 + s2
-        s1 = s1 / sum_s if sum_s > 0 else 0.0
-        s2 = s2 / sum_s if sum_s > 0 else 0.0
+    # Renormalize so the floor-adjusted shares sum to 1.  This also covers the
+    # single-empty-pool cases: an empty pool keeps share 0 (the floor above is
+    # gated on a non-empty total) and the other share normalizes to 1.  The
+    # divisor is always positive because total == 0 returned early, so at least
+    # one pool is non-empty.
+    sum_s = s1 + s2
+    s1 /= sum_s
+    s2 /= sum_s
 
     n1 = int(round(s1 * target_total)) if total1 > 0 else 0
     n2 = int(round(s2 * target_total)) if total2 > 0 else 0
@@ -268,6 +268,9 @@ def _sample_entries(entries: list, count: int, rng=None) -> list:
 def _dch_rng(config: Config, iteration_number: int):
     """Return a seeded RNG for DCH sampling, or None when no seed is configured.
 
+    Logs the effective seed when one is in play, so the run that produced a
+    given sample is identifiable from its log alone.
+
     The seed is composed with the iteration index rather than added to it, so
     iterations of one run draw different samples (which is the point of running
     them) while any given iteration is reproducible across runs.  String
@@ -281,6 +284,7 @@ def _dch_rng(config: Config, iteration_number: int):
     seed = config.global_settings.get("DCH_SAMPLE_SEED")
     if seed is None:
         return None
+    logger.info(f"DCH sampling seed: {seed} (iteration {iteration_number})")
     return random.Random(f"{seed}:{iteration_number}")
 
 
@@ -413,12 +417,6 @@ def process_results(
         logger.info(f"DCH Sampling: Candidate 2 has {len(v2)} relevant abstracts")
 
         rng = _dch_rng(config, iteration_number)
-        if rng is not None:
-            logger.info(
-                f"DCH sampling seed: {config.global_settings.get('DCH_SAMPLE_SEED')} "
-                f"(iteration {iteration_number})"
-            )
-
         consolidated_abstracts, expected_count, total_relevant_abstracts = sample_consolidated_abstracts(v1, v2, config, rng)
 
         dch_row = {

--- a/tests/test_dch_sample_allocation.py
+++ b/tests/test_dch_sample_allocation.py
@@ -1,0 +1,153 @@
+"""DCH sample allocation — characterization tests for `_normalize_fractions`.
+
+This function decides how many of the `DCH_SAMPLE_SIZE` abstracts come from
+hypothesis 1's pool versus hypothesis 2's. It therefore sets the evidence
+balance the DCH verdict rests on: skew the allocation and you skew the
+H1-vs-H2 comparison, with nothing in the output revealing it happened.
+
+These tests are deliberately characterization tests — they pin the behavior
+that shipped, not a specification derived independently. The three structural
+invariants (target total, pool caps, minimum floor at default settings) are the
+real contract; the golden-value cases exist so that a refactor of the
+allocation arithmetic has to prove it preserves the exact splits.
+
+`test_min_floor_can_under_deliver_at_high_floor_settings` pins a known defect
+rather than a desired behavior. See its docstring.
+"""
+import pytest
+
+from skimgpt.relevance_helper import _normalize_fractions
+
+# Shipped defaults, from config_template.json.
+DEFAULT_FLOOR = 0.06
+DEFAULT_TARGET = 50
+
+
+# --- structural invariants ---------------------------------------------------
+
+
+@pytest.mark.parametrize("target", [10, 50])
+@pytest.mark.parametrize("total1", [0, 1, 2, 3, 7, 25, 49, 50, 51, 200, 1337])
+@pytest.mark.parametrize("total2", [0, 1, 2, 3, 7, 25, 49, 50, 51, 200, 504])
+def test_allocation_hits_the_target_or_exhausts_the_pools(total1, total2, target):
+    """n1 + n2 must equal the target, or everything available when short."""
+    n1, n2 = _normalize_fractions(total1, total2, DEFAULT_FLOOR, target)
+
+    assert n1 + n2 == min(target, total1 + total2)
+
+
+@pytest.mark.parametrize("target", [10, 50])
+@pytest.mark.parametrize("total1", [0, 1, 3, 25, 51, 1337])
+@pytest.mark.parametrize("total2", [0, 1, 3, 25, 51, 504])
+def test_allocation_never_exceeds_either_pool(total1, total2, target):
+    """Over-allocating would make random.sample raise ValueError at draw time."""
+    n1, n2 = _normalize_fractions(total1, total2, DEFAULT_FLOOR, target)
+
+    assert 0 <= n1 <= total1
+    assert 0 <= n2 <= total2
+
+
+@pytest.mark.parametrize("total1", [1, 2, 3, 5, 12, 30, 100, 1337])
+@pytest.mark.parametrize("total2", [1, 2, 3, 5, 12, 504, 1500, 9000])
+def test_min_floor_is_honored_at_default_settings(total1, total2):
+    """At the shipped floor/target, the weaker pool always gets its minimum.
+
+    The floor exists so a small pool still contributes evidence rather than
+    being rounded out of the comparison entirely. Verified exhaustively at the
+    default settings; see the under-delivery test below for where it breaks.
+    """
+    n1, n2 = _normalize_fractions(total1, total2, DEFAULT_FLOOR, DEFAULT_TARGET)
+    floor_count = round(DEFAULT_FLOOR * DEFAULT_TARGET)
+
+    assert n1 >= min(total1, floor_count)
+    assert n2 >= min(total2, floor_count)
+
+
+# --- golden allocations ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "total1,total2,expected",
+    [
+        # Empty pools.
+        (0, 0, (0, 0)),
+        (0, 10, (0, 10)),
+        (10, 0, (10, 0)),
+        (0, 1, (0, 1)),
+        (1, 0, (1, 0)),
+        # Both pools smaller than the target — take everything.
+        (1, 1, (1, 1)),
+        (2, 2, (2, 2)),
+        (3, 3, (3, 3)),
+        # Exactly the target.
+        (25, 25, (25, 25)),
+        # Balanced and larger than the target — an even split.
+        (100, 100, (25, 25)),
+        # Heavily skewed pools — the floor lifts the weaker side.
+        (5, 1500, (3, 47)),
+        (30, 1800, (3, 47)),
+        # Weaker pool below even the floor — capped at what exists.
+        (1, 999, (1, 49)),
+        # A real observed run (tools/integration_test_run.log).
+        (1337, 504, (36, 14)),
+    ],
+)
+def test_golden_allocations_at_default_settings(total1, total2, expected):
+    assert _normalize_fractions(total1, total2, DEFAULT_FLOOR, DEFAULT_TARGET) == expected
+
+
+def test_allocation_is_symmetric_under_pool_swap():
+    """Swapping the pools must mirror the split — neither hypothesis is favored."""
+    for total1, total2 in [(5, 1500), (30, 1800), (1337, 504), (1, 999), (7, 12)]:
+        n1, n2 = _normalize_fractions(total1, total2, DEFAULT_FLOOR, DEFAULT_TARGET)
+        swapped = _normalize_fractions(total2, total1, DEFAULT_FLOOR, DEFAULT_TARGET)
+
+        assert swapped == (n2, n1), f"asymmetry at ({total1}, {total2})"
+
+
+# --- known defect ------------------------------------------------------------
+
+
+def test_min_floor_can_under_deliver_at_high_floor_settings():
+    """KNOWN DEFECT, pinned deliberately — this is not desired behavior.
+
+    The floor is applied as ``max(share, min_floor)``, but both shares are then
+    renormalized by their sum, which divides the floored share back down below
+    the floor. So DCH_MIN_SAMPLING_FRACTION is not actually guaranteed.
+
+    At the shipped defaults (0.06 / 50) the rounding hides it completely — a
+    sweep of ~1M combinations found zero violations, which is why nothing has
+    noticed. It surfaces as the floor or target rises, and the shortfall grows
+    with the floor: short by 1 at floor=0.06/target=200, by 3 at
+    floor=0.2/target=100, by 16 at floor=0.33/target=200. Whoever first raises
+    DCH_MIN_SAMPLING_FRACTION to get a more balanced comparison silently gets
+    less balance than they asked for.
+
+    If this is fixed, delete this test — do not adjust its numbers to match.
+    """
+    floor, target = 0.06, 200
+    n1, n2 = _normalize_fractions(12, 1504, floor, target)
+
+    assert (n1, n2) == (11, 189)
+    assert n1 < round(floor * target)  # asked for 12, got 11
+
+
+# --- degenerate inputs -------------------------------------------------------
+
+
+def test_both_pools_empty_allocates_nothing():
+    assert _normalize_fractions(0, 0, DEFAULT_FLOOR, DEFAULT_TARGET) == (0, 0)
+
+
+def test_zero_target_allocates_nothing():
+    assert _normalize_fractions(100, 100, DEFAULT_FLOOR, 0) == (0, 0)
+
+
+def test_zero_floor_falls_back_to_proportional_split():
+    """Without a floor, the split tracks pool sizes proportionally."""
+    n1, n2 = _normalize_fractions(1000, 1000, 0.0, 50)
+    assert (n1, n2) == (25, 25)
+
+    n1, n2 = _normalize_fractions(1800, 200, 0.0, 50)
+    assert n1 + n2 == 50
+    assert n1 > n2


### PR DESCRIPTION
Stacked on #132 — base is `dch-sample-seed`, so this diff shows only the cleanup. GitHub retargets it to `main` automatically once #132 merges.

Applies the cleanup items identified while reviewing the sampling path.

## 1. `_normalize_fractions` had no tests

It decides how many of the `DCH_SAMPLE_SIZE` abstracts come from H1's pool versus H2's — the evidence balance the DCH verdict rests on. Skew it and you skew the comparison, with nothing in the output revealing it. 58 lines of unguarded arithmetic.

Adds `tests/test_dch_sample_allocation.py` covering:

- **Structural invariants** — allocation hits the target or exhausts the pools; never exceeds either pool (over-allocating would make `random.sample` raise at draw time); honors the minimum floor at shipped defaults
- **Golden splits** at the default `0.06`/`50`, including the real `(1337, 504) → (36, 14)` case from `tools/integration_test_run.log`
- **Pool-swap symmetry** — `f(a, b) == reversed(f(b, a))`, so neither hypothesis is structurally favored. This property was previously unverified; it holds
- **Degenerate inputs** — empty pools, zero target, zero floor

## 2. Redundant special cases collapsed

```python
-    if s1 == 0 and s2 > 0:
-        s2 = 1.0
-    elif s2 == 0 and s1 > 0:
-        s1 = 1.0
-    else:
-        sum_s = s1 + s2
-        ...
```

Those branches are reachable, but for **every** input they produce exactly what the `else` renormalization already computes. The `sum_s > 0` guard goes too — the `total == 0` early return already guarantees a non-empty pool.

Verified behavior-identical to the previous implementation across **370,881** `(total1, total2, floor, target)` combinations — **0 mismatches**. The characterization tests were written against the pre-refactor code and pass unchanged.

## 3. Known defect pinned, not fixed

`test_min_floor_can_under_deliver_at_high_floor_settings` documents real misbehavior: the floor is applied as `max(share, min_floor)`, then both shares are renormalized by their sum — which divides the floored share back *below* the floor. So `DCH_MIN_SAMPLING_FRACTION` is not actually guaranteed.

| floor | target | worst shortfall |
|---|---|---|
| **0.06** | **50** (shipped) | **none — 0 violations in ~1M combos** |
| 0.06 | 200 | 1 |
| 0.1 | 200 | 2 |
| 0.2 | 100 | 3 |
| 0.33 | 200 | 16 |

Invisible today because rounding at the defaults hides it entirely. It surfaces for whoever first raises `DCH_MIN_SAMPLING_FRACTION` to get a more balanced comparison — they silently get less balance than they asked for.

Pinned rather than fixed because a fix changes sample composition at non-default settings, which is a call for the maintainer, not a drive-by. The test says so explicitly and tells a future fixer to delete it rather than adjust its numbers.

## 4. Minor

Folds the DCH seed log line into `_dch_rng`, which already reads the key, instead of reading `DCH_SAMPLE_SEED` a second time at the call site.

## Testing

`pytest tests/` — **446 passed** (49 before this PR, 397 added).

## Considered and rejected

- **Looping over the `total1`/`total2`, `n1`/`n2`, `sampled1`/`sampled2` pairs.** DCH is definitionally two hypotheses; a loop over a 2-list buys indirection, not clarity.
- **Consolidating the three count-adjustment mechanisms** in `_normalize_fractions` (the `diff > 0` loop, the clamp, then the `remaining > 0` top-up — all doing largest-remainder allocation). A genuine simplification, but it should follow the floor decision above rather than precede it, since both touch the same arithmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)