### PR TITLE
fix: enforce DCH_MIN_SAMPLING_FRACTION in count space

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,11 @@ This configuration file contains various settings for different job types. Below
 - `LOG_LEVEL`: Logging level (e.g., `"INFO"`).
 - `OUTDIR_SUFFIX`: Suffix for the output directory (e.g., `""`).
 - `iterations`: Number of iterations for processing (e.g., `3`).
-- `DCH_MIN_SAMPLING_FRACTION`: Minimum sampling fraction for DCH (e.g., `0.06`).
+- `DCH_MIN_SAMPLING_FRACTION`: Minimum share of `DCH_SAMPLE_SIZE` guaranteed to each
+  candidate, so a small abstract pool still contributes evidence instead of being
+  rounded out of the comparison (e.g., `0.06` — at least 3 of 50). Capped by what a
+  pool actually holds: a pool of 1 contributes 1. Values above `0.5` cannot be
+  honored for both candidates and fall back to an even split with a logged warning.
 - `DCH_SAMPLE_SIZE`: Sample size for DCH (e.g., `50`).
 - `DCH_SAMPLE_SEED`: Integer seed for DCH abstract sampling, or `null` for unseeded
   (default). When set, each iteration draws a reproducible sample — iterations still

--- a/skimgpt/relevance_helper.py
+++ b/skimgpt/relevance_helper.py
@@ -192,60 +192,58 @@ def _normalize_fractions(
 ) -> tuple[int, int]:
     """Compute sample counts for two pools, enforcing a minimum fraction and target total.
 
+    Allocates proportionally to pool size, then lifts whichever pool falls below
+    ``min_floor`` of the requested sample up to that floor, taking the shortfall
+    from the other pool.
+
+    The floor is enforced in count space on purpose.  This function previously
+    applied it to the proportional *shares* (``max(share, min_floor)``) and then
+    renormalized those shares by their sum, which divided the floored share back
+    down below the floor — so ``DCH_MIN_SAMPLING_FRACTION`` was not actually
+    guaranteed.  Rounding hid it entirely at the shipped 0.06/50 defaults, but it
+    under-delivered by up to 16 abstracts at floor=0.33/target=200, which would
+    have bitten whoever first raised the floor to get a more balanced comparison.
+
     Returns:
         ``(n1, n2)`` — the number of items to sample from each pool.
     """
-    total = total1 + total2
-    if total == 0:
+    available = min(target_total, total1 + total2)
+    if available <= 0:
         return 0, 0
 
-    s1 = total1 / total
-    s2 = total2 / total
+    # Proportional allocation.  Deriving n2 by subtraction rather than rounding it
+    # independently makes the counts sum to `available` by construction, which is
+    # why this needs no remainder-reconciliation pass.
+    n1 = min(total1, int(round(total1 / (total1 + total2) * available)))
+    n2 = available - n1
+    if n2 > total2:
+        n2 = total2
+        n1 = available - n2
 
-    if total1 > 0:
-        s1 = max(s1, min_floor)
-    if total2 > 0:
-        s2 = max(s2, min_floor)
+    # Minimum representation per pool, capped by what the pool actually holds.
+    floor_count = int(round(min_floor * target_total))
+    floor1 = min(total1, floor_count)
+    floor2 = min(total2, floor_count)
 
-    # Renormalize so the floor-adjusted shares sum to 1.  This also covers the
-    # single-empty-pool cases: an empty pool keeps share 0 (the floor above is
-    # gated on a non-empty total) and the other share normalizes to 1.  The
-    # divisor is always positive because total == 0 returned early, so at least
-    # one pool is non-empty.
-    sum_s = s1 + s2
-    s1 /= sum_s
-    s2 /= sum_s
+    if floor1 + floor2 > available:
+        # Both floors cannot be honored — reachable only when min_floor exceeds
+        # 0.5, or when a small target leaves too few slots.  Split as evenly as
+        # the pools allow rather than silently favoring one hypothesis.
+        logger.warning(
+            f"DCH_MIN_SAMPLING_FRACTION={min_floor} cannot be honored for both "
+            f"candidates with {available} slots available; splitting evenly."
+        )
+        n1 = min(total1, available // 2)
+        n2 = min(total2, available - n1)
+        return min(total1, available - n2), n2
 
-    n1 = int(round(s1 * target_total)) if total1 > 0 else 0
-    n2 = int(round(s2 * target_total)) if total2 > 0 else 0
-
-    diff = target_total - (n1 + n2)
-    if diff > 0:
-        for _ in range(diff):
-            cap1 = total1 - n1
-            cap2 = total2 - n2
-            if (s1 >= s2 and cap1 > 0) or cap2 <= 0:
-                n1 += 1 if cap1 > 0 else 0
-            else:
-                n2 += 1 if cap2 > 0 else 0
-    elif diff < 0:
-        for _ in range(-diff):
-            if n1 >= n2 and n1 > 0:
-                n1 -= 1
-            elif n2 > 0:
-                n2 -= 1
-
-    n1 = min(n1, total1)
-    n2 = min(n2, total2)
-
-    remaining = target_total - (n1 + n2)
-    if remaining > 0:
-        add1 = min(remaining, total1 - n1)
-        n1 += add1
-        remaining -= add1
-        if remaining > 0:
-            add2 = min(remaining, total2 - n2)
-            n2 += add2
+    # At most one pool can sit below its floor: if both did, their counts would
+    # sum to less than floor1 + floor2 <= available, yet they sum to exactly
+    # available.  So lifting one always leaves the other at or above its floor.
+    if n1 < floor1:
+        n1, n2 = floor1, available - floor1
+    elif n2 < floor2:
+        n1, n2 = available - floor2, floor2
 
     return n1, n2
 

--- a/tests/test_dch_sample_allocation.py
+++ b/tests/test_dch_sample_allocation.py
@@ -5,14 +5,15 @@ hypothesis 1's pool versus hypothesis 2's. It therefore sets the evidence
 balance the DCH verdict rests on: skew the allocation and you skew the
 H1-vs-H2 comparison, with nothing in the output revealing it happened.
 
-These tests are deliberately characterization tests — they pin the behavior
-that shipped, not a specification derived independently. The three structural
-invariants (target total, pool caps, minimum floor at default settings) are the
-real contract; the golden-value cases exist so that a refactor of the
-allocation arithmetic has to prove it preserves the exact splits.
+Most of these are characterization tests — they pin the behavior that shipped,
+not a specification derived independently. The structural invariants (target
+total, pool caps, minimum floor) are the real contract; the golden-value cases
+exist so that a refactor of the allocation arithmetic has to prove it preserves
+the exact splits.
 
-`test_min_floor_can_under_deliver_at_high_floor_settings` pins a known defect
-rather than a desired behavior. See its docstring.
+The one place the tests assert *changed* behavior is the minimum floor: it used
+to under-deliver at high floor/target settings, and those cases are now
+regression cover rather than pinned defects.
 """
 import pytest
 
@@ -105,31 +106,55 @@ def test_allocation_is_symmetric_under_pool_swap():
         assert swapped == (n2, n1), f"asymmetry at ({total1}, {total2})"
 
 
-# --- known defect ------------------------------------------------------------
+# --- minimum floor at non-default settings -----------------------------------
+#
+# The floor used to be applied to the proportional shares and then renormalized
+# by their sum, which divided the floored share back below the floor. These
+# cases are the ones that exposed it; they are kept as regression cover.
 
 
-def test_min_floor_can_under_deliver_at_high_floor_settings():
-    """KNOWN DEFECT, pinned deliberately — this is not desired behavior.
+@pytest.mark.parametrize("floor", [0.02, 0.06, 0.1, 0.2, 0.33, 0.5])
+@pytest.mark.parametrize("target", [5, 10, 20, 50, 100, 200])
+@pytest.mark.parametrize("total1,total2", [(12, 1504), (10, 1000), (1, 999), (30, 1800), (5, 9000)])
+def test_min_floor_is_honored_at_every_setting(floor, target, total1, total2):
+    """The floor holds regardless of how high min_floor or the target is set."""
+    n1, n2 = _normalize_fractions(total1, total2, floor, target)
+    floor_count = round(floor * target)
 
-    The floor is applied as ``max(share, min_floor)``, but both shares are then
-    renormalized by their sum, which divides the floored share back down below
-    the floor. So DCH_MIN_SAMPLING_FRACTION is not actually guaranteed.
+    assert n1 >= min(total1, floor_count)
+    assert n2 >= min(total2, floor_count)
+    assert n1 + n2 == min(target, total1 + total2)
 
-    At the shipped defaults (0.06 / 50) the rounding hides it completely — a
-    sweep of ~1M combinations found zero violations, which is why nothing has
-    noticed. It surfaces as the floor or target rises, and the shortfall grows
-    with the floor: short by 1 at floor=0.06/target=200, by 3 at
-    floor=0.2/target=100, by 16 at floor=0.33/target=200. Whoever first raises
-    DCH_MIN_SAMPLING_FRACTION to get a more balanced comparison silently gets
-    less balance than they asked for.
 
-    If this is fixed, delete this test — do not adjust its numbers to match.
-    """
-    floor, target = 0.06, 200
-    n1, n2 = _normalize_fractions(12, 1504, floor, target)
+def test_high_floor_lifts_the_weaker_pool_to_its_full_entitlement():
+    """Regression: this returned (11, 189) — one short of the 12 the floor asks for."""
+    assert _normalize_fractions(12, 1504, 0.06, 200) == (12, 188)
 
-    assert (n1, n2) == (11, 189)
-    assert n1 < round(floor * target)  # asked for 12, got 11
+
+def test_worst_previous_shortfall_now_delivers_the_floor():
+    """Regression: floor=0.33/target=200 used to come up 16 abstracts short."""
+    n1, n2 = _normalize_fractions(80, 9000, 0.33, 200)
+
+    assert n1 >= round(0.33 * 200)
+    assert n1 + n2 == 200
+
+
+def test_unsatisfiable_floors_split_evenly(caplog):
+    """min_floor > 0.5 cannot be honored for two pools — split rather than skew."""
+    with caplog.at_level("WARNING"):
+        n1, n2 = _normalize_fractions(1000, 1000, 0.6, 50)
+
+    assert (n1, n2) == (25, 25)
+    assert "cannot be honored" in caplog.text
+
+
+def test_unsatisfiable_floors_respect_pool_caps():
+    """An even split must still never over-allocate a small pool."""
+    n1, n2 = _normalize_fractions(4, 1000, 0.6, 50)
+
+    assert n1 <= 4
+    assert n2 <= 1000
+    assert n1 + n2 == 50
 
 
 # --- degenerate inputs -------------------------------------------------------
@@ -141,6 +166,19 @@ def test_both_pools_empty_allocates_nothing():
 
 def test_zero_target_allocates_nothing():
     assert _normalize_fractions(100, 100, DEFAULT_FLOOR, 0) == (0, 0)
+
+
+def test_odd_slot_tie_break_is_fixed_by_convention():
+    """Equal pools with an odd slot count: the tie-break is arbitrary but pinned.
+
+    `int(round(...))` is banker's rounding, so an exact .5 share resolves to the
+    even count — which hands the odd slot to candidate 2 here. The direction is
+    not meaningful; it is pinned so a change of rounding mode has to be a
+    deliberate decision rather than a silent side effect. Unreachable at the
+    shipped DCH_SAMPLE_SIZE of 50, where equal pools split exactly 25/25.
+    """
+    assert _normalize_fractions(1, 1, DEFAULT_FLOOR, 1) == (0, 1)
+    assert _normalize_fractions(10, 10, DEFAULT_FLOOR, 50) == (10, 10)
 
 
 def test_zero_floor_falls_back_to_proportional_split():


### PR DESCRIPTION
Fixes the defect pinned by `test_min_floor_can_under_deliver_at_high_floor_settings` in #133. That test is deleted here rather than adjusted, as its docstring instructed.

## The bug

The floor was applied to the proportional shares:

```python
s1 = max(s1, min_floor)      # lift the weaker share to the floor
...
s1 /= (s1 + s2)              # ...then divide it straight back down
```

Renormalizing after flooring divides the floored share below the floor again, so `DCH_MIN_SAMPLING_FRACTION` was never actually guaranteed. A small abstract pool could contribute less evidence than the configured minimum — silently, and in favor of the larger pool.

Rounding hid it completely at the shipped `0.06`/`50` defaults, which is why nothing noticed. It surfaces as the floor rises:

| floor | target | was short by |
|---|---|---|
| **0.06** | **50** (shipped) | **not reachable** |
| 0.06 | 200 | 1 |
| 0.2 | 100 | 3 |
| 0.33 | 200 | 16 |

So it would have bitten whoever first raised `DCH_MIN_SAMPLING_FRACTION` to get a more balanced H1-vs-H2 comparison — exactly what the knob is for.

## The fix

Allocate proportionally in count space, then lift whichever pool sits below its floor and take the shortfall from the other. At most one pool can be below its floor at a time — if both were, their counts would sum to less than `floor1 + floor2 <= available`, yet they sum to exactly `available` — so a single lift always suffices. That proof is in the code comment.

Deriving `n2` by subtraction makes the counts sum to the target by construction, which retires the three separate reconciliation passes the old version needed (the increment loop, the clamp, the top-up). That was cleanup item #4 from the earlier review, which I'd deliberately deferred behind this decision — it falls out of the fix rather than needing its own change.

## Blast radius, measured

Over **370,881** `(total1, total2, floor, target)` combinations:

- **0 changes at the shipped defaults (0.06/50)** — no existing DCH run's allocation moves
- 0 target-total or pool-cap violations
- 0 floor violations anywhere the floor is satisfiable
- Changes confined to (a) high floor/target settings — the defect — and (b) `target <= 5`, where the diffs are tie-breaks and **both** old and new are structurally valid

## Two judgment calls worth flagging

**Banker's rounding kept.** Half-up rounding would be tidier in principle and would cut the tie-break churn, but it introduced **35 allocation changes at the default settings**. Preserving the default exactly matters more than rounding elegance, so `int(round(...))` stays. The tie-break is now pinned by `test_odd_slot_tie_break_is_fixed_by_convention` — arbitrary direction, but no longer able to flip as a silent side effect of a rounding change.

**Floors above 0.5 are unsatisfiable** for two pools. That case now splits evenly and logs a warning, rather than silently favoring one candidate. I did not add config validation rejecting it — a warning at the point of detection carries more information than a startup error, and the value is legal for a single pool.

## Testing

`pytest tests/` — **630 passed** (446 before, 184 added/changed).

The characterization tests from #133 are what made this safe: every golden split passed unchanged against the rewritten function, and the *only* failure was the pinned-defect test flipping to `(12, 188)` with the floor honored.

## Follow-up not taken

`hyp_stats.perm_test` (`skimgpt/visualization/hyp_stats.py`) still uses unseeded `np.random` for its 10,000-permutation test — same family of reproducibility hole, different (post-hoc CLI) path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)