### PR TITLE
feat: add DCH_FIX_SAMPLE_ACROSS_ITERATIONS to isolate LLM variance fr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ This configuration file contains various settings for different job types. Below
   abstract pool being unchanged: if PubMed results or relevance-filter labels shift,
   the same seed yields a different sample. The `Pool fingerprint:` INFO log line
   identifies that case.
+- `DCH_FIX_SAMPLE_ACROSS_ITERATIONS`: Boolean, default `false`. When `true`, one
+  abstract sample is drawn before the iteration loop and every iteration scores that
+  *same* sample, instead of each iteration drawing its own. Use this to isolate the
+  LLM's own output variance from sampling variance — with the default `false`,
+  differences across iterations mix both sources; with this `true`, the input is
+  held constant so any difference across iterations comes from the model alone.
+  This is the opposite intent of `DCH_SAMPLE_SEED`, which keeps iterations
+  *different* from each other on purpose; if both are set, the one fixed draw is
+  made reproducible via the seed, but it is still identical across iterations.
 - `TRITON_MAX_WORKERS`: Concurrent streaming inference workers for Triton (e.g., `10`).
 
 ## HTCONDOR
@@ -141,6 +150,17 @@ This configuration file contains various settings for different job types. Below
   - `on_pair_error`: `"advance_both"` (default, tolerate a failed pairwise comparison) or `"abort_round"` (stop the whole tournament).
   - `pair_retries`: Number of automatic retries for a failed pairwise comparison before applying `on_pair_error` (e.g., `1`).
   - `max_parallel_pairs`: Concurrency cap for pairwise comparisons within a round (e.g., `null` to run every pair in the round at once).
+- `ranking`: Settings for ranking all N B terms via a parallel bubble sort (see [Ranking All B Terms via a Parallel Bubble Sort](#ranking-all-b-terms-via-a-parallel-bubble-sort)). Must leave `is_dch` set to `false` when `ranking.enabled` is `true`.
+  - `enabled`: Boolean flag to turn on ranking mode (e.g., `false`).
+  - `tie_threshold`: Half-width of the tie band around a score of 50, same meaning as in `tournament` (e.g., `5`).
+  - `max_passes`: Hard cap on sort passes (e.g., `null` to auto-compute as `len(B terms) + 2`).
+  - `min_no_evidence_before_quarantine`: Number of times a term must show up with zero supporting abstracts *for itself* in a real (non-cached) comparison before it's pulled out of the active sort (e.g., `1` to quarantine immediately; raise it if quarantining looks too aggressive for noisy/sparse-evidence terms). This checks each term's own support independently, not just symmetric zero-vs-zero ties -- a term with no literature of its own gets flagged even if it lost decisively to a well-evidenced opponent.
+  - `min_errors_before_quarantine`: Number of times a term must be involved in a comparison that failed at the pipeline level (not a scientific "no evidence" result -- a subprocess/infrastructure failure) before it's pulled out (e.g., `2`, giving it a couple of fresh retries first since a failure isn't a reproducible fact about the term the way zero support is).
+  - `enable_escape_comparisons`: Boolean flag for the frozen-tie-chain escape/validation mechanism (e.g., `true`; see the note on it below).
+  - `reseed_every_n_passes`: Every N passes, re-sort the active list by each term's (wins - losses) record so far (e.g., `2`; `0`/`null` to disable). Corrects positions that reflect an accident of the adjacent-sort process rather than a term's actual record -- see the note below.
+  - `seed`: Optional integer seed for reproducible initial shuffling (e.g., `null` for non-reproducible).
+  - `pair_retries`: Number of automatic retries for a failed pairwise comparison (e.g., `1`).
+  - `max_parallel_pairs`: Concurrency cap for pairwise comparisons within a pass (e.g., `null` to run every comparison in the pass at once).
 - `SORT_COLUMN`: Column used for sorting A-B relationships (e.g., `"ab_sort_ratio"`).
 - `ab_fet_threshold`: Fisher Exact Test threshold for A-B relationships (e.g., `1`).
 - `censor_year_upper`: Upper bound year for data censoring (e.g., `1980`).
@@ -298,6 +318,43 @@ If the tournament ended in a tie (multiple entries in `final_terms`), pass `-win
 ```bash
 python summarize_winner.py output/output_<timestamp>_tournament_<suffix> -winner GeneA
 ```
+
+### Ranking All B Terms via a Parallel Bubble Sort
+
+A single-elimination tournament only tells you the winner. To get a full ranking of every B term, use `rank_wrapper.py` instead — it sorts all N terms via **odd-even transposition sort** (the parallelizable version of bubble sort): each pass compares/swaps adjacent pairs in the current order, alternating "even" pairs `(0,1),(2,3),...` and "odd" pairs `(1,2),(3,4),...`, with every comparison in a pass run concurrently (same `is_dch`-per-pair machinery as the tournament).
+
+1. Point `B_TERMS_FILE` at a file with 2+ terms.
+2. In `config.json`, leave `is_dch` set to `false` and set `JOB_SPECIFIC_SETTINGS.km_with_gpt.ranking.enabled` to `true`. Adjust `tie_threshold`, `seed`, etc. as needed (see [Job-Specific Settings](#job-specific-settings) above).
+3. Run:
+
+   ```bash
+   python rank_wrapper.py
+   ```
+
+Comparisons and swaps work similarly to the tournament's tie/support logic, with one difference: a ranking has to place every term somewhere, so terms can't just be eliminated -- instead, unresolvable ones are pulled out of the active sort and appended to the bottom.
+- A clear score swaps the pair into the correct relative order (or leaves it, if already correct).
+- A tie where both sides have real support leaves the pair as-is (no strict preference either way).
+- **Zero-support quarantine**: each term's own supporting-abstract count is checked in *every* real comparison it's part of, not just symmetric ties -- a term with no literature of its own gets flagged even if it happened to lose decisively to a well-evidenced opponent. Once a term crosses `min_no_evidence_before_quarantine`, it's pulled from the active sort (`quarantine_reason: "no_evidence"`). This matters because such a term never swaps regardless of its neighbor, so left in place it becomes an immovable wall that can block correct ordering of the terms on either side of it.
+- **Repeated-error quarantine**: a comparison can fail at the pipeline/infrastructure level (not a scientific finding -- e.g. a relevance-filtering worker crashing) and come back with no usable score at all. These failures are never cached, so the pair always gets a fresh attempt if it becomes adjacent again; but if a term racks up `min_errors_before_quarantine` real failures, it's pulled out too (`quarantine_reason: "repeated_error"`) rather than blocking the sort indefinitely.
+- The same two terms are never actually re-compared twice across the whole sort for a real (successful) result — results are cached by unordered pair and reused if they become adjacent again in a later pass. Cached reuses don't count toward win/loss/tie/error tallies or quarantine thresholds, since they're the same underlying observation, not a new one.
+- **Frozen-tie-chain boundary checks**: when several adjacent *genuine* ties chain together (e.g. `X ≈ Y ≈ Z`, each with real evidence on both sides), the whole chain freezes solid — nothing inside it can swap past either boundary, since that requires a decisive result there, and the boundary is tied too. A term buried in the middle of such a chain never gets independently compared to anything outside it — it just inherits the block's position. Every pass, at most one frozen chain gets one real boundary comparison (never both directions in the same pass, to avoid two swaps corrupting each other's position bookkeeping):
+  - **Upward escape**: the chain's **deepest** untried member vs. its **upward** neighbor. A win relocates it above the whole chain, breaking it free. Tests whether a buried member is secretly *better* than what's above.
+  - **Downward validation**: the chain's **shallowest** untried member vs. its **downward** neighbor. A loss relocates it below the whole chain. Tests whether a member is secretly *worse* than what's below — the tied block moves together, but normally only the outward-facing member's relationship to that neighbor is ever checked, so other members can silently inherit a position they never earned (see below).
+
+  Either way, a tie/no-change result is cached and the next untried member gets a turn on a later pass. Controlled by `enable_escape_comparisons`. **Known v1 limitation**: each direction only tests one hop per chain per opportunity. If the immediate neighbor is itself an unresolvable tie, a buried/inherited term won't get tested against anyone further out in the same run.
+
+- **Periodic re-seed by record**: every `reseed_every_n_passes` passes, the active list is re-sorted by each term's (wins − losses) tally so far (ties in record keep their current relative order — a stable sort, so no preference is invented where there isn't evidence for one). This catches positions that reflect an accident of the adjacent-sort process rather than a term's actual record — e.g. a tied pair that got positionally "teleported" upward because unrelated neighbors above it were quarantined away, without ever having to beat what it's now sitting above. Right after re-seeding, any adjacent pair the re-seed placed in an order that contradicts an *already-known direct comparison* between them is immediately swapped back (using only the existing cache, no new comparisons) — otherwise a term's aggregate record (which reflects different opponents) could repeatedly override a specific head-to-head result the sort had already correctly resolved, oscillating forever instead of converging.
+
+The sort stops as soon as one full even+odd cycle produces no swaps, no new quarantines, and no re-seed changes (confirmed sorted), or `max_passes` is reached.
+
+Output (under `output/output_<timestamp>_rank_<suffix>/`):
+- `pass_<n>_<even|odd>/output/<pair_id>/` — a normal single-pair `is_dch` output directory for every *freshly run* comparison in pass `n` (passes made entirely of cache hits don't create any output directory).
+- `pass_<n>_escape/output/escape<idx>_<pair_id>/` and `pass_<n>_validate/output/validate<idx>_<pair_id>/` — the one boundary comparison (if any) run during pass `n`.
+- `ranking_history.json` — full pass-by-pass record (comparisons, scores, outcomes, swaps, per-term support flags, `boundary_kind`, `reseeded` flag) plus the `final_ranking` (rank, term, win/tie/loss/error counts, `avg_score`, `scores`, `insufficient_evidence` flag, `quarantine_reason`).
+- `ranking_summary.tsv` — flat table, one row per comparison across all passes (plus a marker row for any pass where a re-seed happened), including a `Boundary_Kind` column (`escape`, `validate`, or blank for a normal comparison).
+- `FINAL_RANKING.txt` — the numbered final ranking, with each term's `avg_score`, and insufficient-evidence/unresolved terms flagged.
+
+Each term's `avg_score` (and the underlying `scores` list in the JSON) averages every real comparison it was part of, corrected to that term's own perspective: a comparison's score is always recorded from term_i/H1's point of view (100 favors term_i, 0 favors term_j), so when a term was term_j in a given comparison, `100 - score` is used instead before averaging. Cache-hit reuses and errored comparisons are excluded (same reasoning as the win/tie/loss tallies) so the same underlying observation is never counted twice.
 
 ## Use web interface to run KM/Skim
 

--- a/config_template.json
+++ b/config_template.json
@@ -26,6 +26,7 @@
         "DCH_MIN_SAMPLING_FRACTION": 0.06,
         "DCH_SAMPLE_SIZE": 50,
         "DCH_SAMPLE_SEED": null,
+        "DCH_FIX_SAMPLE_ACROSS_ITERATIONS": false,
         "TRITON_MAX_WORKERS": 10
     },
     "HTCONDOR": {
@@ -59,6 +60,18 @@
                 "max_consecutive_stalls": 2,
                 "seed": null,
                 "on_pair_error": "advance_both",
+                "pair_retries": 1,
+                "max_parallel_pairs": null
+            },
+            "ranking": {
+                "enabled": false,
+                "tie_threshold": 5,
+                "max_passes": null,
+                "min_no_evidence_before_quarantine": 1,
+                "min_errors_before_quarantine": 2,
+                "enable_escape_comparisons": true,
+                "reseed_every_n_passes": 2,
+                "seed": null,
                 "pair_retries": 1,
                 "max_parallel_pairs": null
             },

--- a/skimgpt/relevance_helper.py
+++ b/skimgpt/relevance_helper.py
@@ -34,6 +34,13 @@ def _flatten_if_nested(data):
     return data
 
 
+def _get_dch_pools(out_df: pd.DataFrame) -> tuple[list, list]:
+    """Extract and flatten the two DCH candidate abstract pools from out_df."""
+    v1_all_raw = out_df.iloc[0].get("ab_abstracts", [])
+    v2_all_raw = out_df.iloc[1].get("ab_abstracts", [])
+    return _flatten_if_nested(v1_all_raw), _flatten_if_nested(v2_all_raw)
+
+
 def _dedup_by_pmid(abstracts, seen_pmids):
     """Return abstracts with duplicate PMIDs removed, updating seen_pmids in place."""
     deduped = []
@@ -371,6 +378,7 @@ def process_results(
     num_abstracts_fetched: int,
     output_base_dir: str,
     iteration_number: int = 0,
+    fixed_sample: tuple[str, int, int] | None = None,
 ) -> None:
     """Process results and write to JSON files.
 
@@ -384,6 +392,10 @@ def process_results(
         iteration_number: 1-indexed iteration index; 0 means "not iterated".
             Threaded through as a parameter (not read from config) so multiple
             iterations can run concurrently without racing on shared state.
+        fixed_sample: When set (DCH only), reuse this
+            ``(consolidated_abstracts, expected_count, total_relevant_abstracts)``
+            tuple instead of drawing a fresh sample, so every iteration scores
+            the identical abstract set. See ``config.dch_fix_sample_across_iterations``.
     """
     total_rows = len(out_df)
     logger.info(f"Processing {total_rows} results...")
@@ -406,16 +418,17 @@ def process_results(
         logger.debug(f"hyp1: {hyp1}")
         logger.debug(f"hyp2: {hyp2}")
 
-        v1_all_raw = out_df.iloc[0].get("ab_abstracts", [])
-        v2_all_raw = out_df.iloc[1].get("ab_abstracts", [])
+        if fixed_sample is not None:
+            consolidated_abstracts, expected_count, total_relevant_abstracts = fixed_sample
+            logger.info("DCH Sampling: reusing fixed sample across iterations "
+                        f"({expected_count}/{total_relevant_abstracts} abstracts)")
+        else:
+            v1, v2 = _get_dch_pools(out_df)
+            logger.info(f"DCH Sampling: Candidate 1 has {len(v1)} relevant abstracts")
+            logger.info(f"DCH Sampling: Candidate 2 has {len(v2)} relevant abstracts")
 
-        v1 = _flatten_if_nested(v1_all_raw)
-        v2 = _flatten_if_nested(v2_all_raw)
-        logger.info(f"DCH Sampling: Candidate 1 has {len(v1)} relevant abstracts")
-        logger.info(f"DCH Sampling: Candidate 2 has {len(v2)} relevant abstracts")
-
-        rng = _dch_rng(config, iteration_number)
-        consolidated_abstracts, expected_count, total_relevant_abstracts = sample_consolidated_abstracts(v1, v2, config, rng)
+            rng = _dch_rng(config, iteration_number)
+            consolidated_abstracts, expected_count, total_relevant_abstracts = sample_consolidated_abstracts(v1, v2, config, rng)
 
         dch_row = {
             "hypothesis1": hyp1,
@@ -574,6 +587,15 @@ def run_iterations(config: Config, out_df: pd.DataFrame, num_abstracts_fetched: 
         for i in range(1, num_iterations + 1):
             os.makedirs(os.path.join(output_base_dir, f"iteration_{i}"), exist_ok=True)
 
+        fixed_sample = None
+        if config.is_dch and config.dch_fix_sample_across_iterations:
+            v1, v2 = _get_dch_pools(out_df)
+            rng = _dch_rng(config, 1)
+            fixed_sample = sample_consolidated_abstracts(v1, v2, config, rng)
+            logger.info("DCH_FIX_SAMPLE_ACROSS_ITERATIONS enabled: drawing one sample "
+                        f"({fixed_sample[1]}/{fixed_sample[2]} abstracts) and reusing it "
+                        f"across all {num_iterations} iterations")
+
         max_parallel = min(ITERATION_MAX_PARALLELISM, num_iterations)
         total_start = time.time()
         logger.info(f"Running {num_iterations} iterations with parallelism={max_parallel}")
@@ -582,7 +604,8 @@ def run_iterations(config: Config, out_df: pd.DataFrame, num_abstracts_fetched: 
             t0 = time.time()
             process_results(out_df, config, num_abstracts_fetched,
                             output_base_dir=output_base_dir,
-                            iteration_number=iteration)
+                            iteration_number=iteration,
+                            fixed_sample=fixed_sample)
             return iteration, time.time() - t0
 
         with ThreadPoolExecutor(max_workers=max_parallel) as ex:

--- a/skimgpt/utils.py
+++ b/skimgpt/utils.py
@@ -431,6 +431,12 @@ class Config:
         self.min_word_count = self.global_settings["MIN_WORD_COUNT"]
         self.iterations = self.global_settings.get("iterations", False)
         self.current_iteration = 0
+        # When True, every iteration reuses the same DCH abstract sample
+        # instead of drawing a fresh one, isolating LLM output variance from
+        # sampling variance.
+        self.dch_fix_sample_across_iterations = self.global_settings.get(
+            "DCH_FIX_SAMPLE_ACROSS_ITERATIONS", False
+        )
         self.temperature = self.filter_config["TEMPERATURE"]
         self.top_p = self.filter_config["TOP_P"]
         self.max_cot_tokens = self.filter_config["MAX_COT_TOKENS"]

--- a/tests/test_dch_fix_sample_across_iterations.py
+++ b/tests/test_dch_fix_sample_across_iterations.py
@@ -1,0 +1,146 @@
+"""DCH_FIX_SAMPLE_ACROSS_ITERATIONS — locks in the fixed-sample-across-iterations contract.
+
+This is the complement to DCH_SAMPLE_SEED (see test_dch_sample_seed.py): that
+flag deliberately keeps iterations *different* from each other (reproducible
+per-run, varying per-iteration) so N iterations measure something. This flag
+does the opposite on purpose — it holds the abstract sample identical across
+every iteration of a run, so that any variation across iterations can only
+come from the LLM itself, not from sampling a different set of abstracts each
+time. Without this test, a refactor that moved the sampling call back inside
+the per-iteration path would silently turn the LLM-variance measurement back
+into a mix of LLM variance and sampling variance.
+"""
+import threading
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pandas as pd
+
+from skimgpt.relevance_helper import run_iterations
+
+DELIMITER = "===END OF ABSTRACT==="
+
+
+def _pool(prefix: str, count: int) -> list[str]:
+    return [
+        f"Title {prefix}{i}. Abstract body {prefix}{i}. PMID: {prefix}{i:04d}{DELIMITER}"
+        for i in range(count)
+    ]
+
+
+def _dch_out_df(v1_count=200, v2_count=80) -> pd.DataFrame:
+    return pd.DataFrame([
+        {"a_term": "A1", "b_term": "B1", "ab_abstracts": _pool("1", v1_count)},
+        {"a_term": "A2", "b_term": "B2", "ab_abstracts": _pool("2", v2_count)},
+    ])
+
+
+def _dch_config(iterations, fix_sample_across_iterations, seed=None,
+                sample_size=10, min_fraction=0.06):
+    return SimpleNamespace(
+        iterations=iterations,
+        current_iteration=999,
+        is_dch=True,
+        is_km_with_gpt=True,
+        is_skim_with_gpt=False,
+        dch_fix_sample_across_iterations=fix_sample_across_iterations,
+        global_settings={
+            "DCH_SAMPLE_SEED": seed,
+            "DCH_SAMPLE_SIZE": sample_size,
+            "DCH_MIN_SAMPLING_FRACTION": min_fraction,
+        },
+    )
+
+
+def _run_and_capture_samples(config, out_df, tmp_path):
+    """Run run_iterations with process_single_row stubbed; return each
+    iteration's consolidated ab_abstracts string.
+
+    Iterations run concurrently in a thread pool and each rebuilds its own
+    single-row DataFrame indexed at 0, so captures are collected into a
+    lock-protected list rather than keyed by row identity — keying by row
+    identity would let later iterations silently overwrite earlier ones.
+    """
+    captured = []
+    lock = threading.Lock()
+
+    def fake_process_single_row(row, _config):
+        with lock:
+            captured.append(row["ab_abstracts"])
+        return None
+
+    with patch("skimgpt.relevance_helper.process_single_row", fake_process_single_row), \
+         patch("skimgpt.relevance_helper.get_hypothesis", lambda **_k: "hyp"), \
+         patch("skimgpt.relevance_helper.write_to_json", lambda *_a, **_k: None):
+        run_iterations(config, out_df, num_abstracts_fetched=280,
+                       output_base_dir=str(tmp_path))
+
+    return captured
+
+
+def test_fixed_sample_is_identical_across_all_iterations(tmp_path):
+    config = _dch_config(iterations=5, fix_sample_across_iterations=True)
+    out_df = _dch_out_df()
+
+    samples = _run_and_capture_samples(config, out_df, tmp_path)
+
+    assert len(samples) == 5
+    distinct = set(samples)
+    assert len(distinct) == 1, "every iteration must score the identical sample"
+
+
+def test_unfixed_sampling_still_varies_across_iterations(tmp_path):
+    """Default (flag off) behavior must be untouched: independent draws per iteration."""
+    config = _dch_config(iterations=5, fix_sample_across_iterations=False)
+    out_df = _dch_out_df()
+
+    samples = _run_and_capture_samples(config, out_df, tmp_path)
+
+    assert len(samples) == 5
+    distinct = set(samples)
+    assert len(distinct) > 1, "unfixed iterations drawing identical samples would be a regression"
+
+
+def test_fixed_sample_reproducible_with_seed(tmp_path_factory):
+    """Combining with DCH_SAMPLE_SEED makes the one fixed draw reproducible across runs."""
+    out_df = _dch_out_df()
+
+    config_a = _dch_config(iterations=3, fix_sample_across_iterations=True, seed=1234)
+    samples_a = _run_and_capture_samples(config_a, out_df, tmp_path_factory.mktemp("run_a"))
+
+    config_b = _dch_config(iterations=3, fix_sample_across_iterations=True, seed=1234)
+    samples_b = _run_and_capture_samples(config_b, out_df, tmp_path_factory.mktemp("run_b"))
+
+    assert set(samples_a) == set(samples_b)
+
+
+def test_fixed_sample_without_seed_varies_across_reruns(tmp_path_factory):
+    """Without a seed, the single fixed draw is still random per run (just constant within it)."""
+    out_df = _dch_out_df()
+
+    config_a = _dch_config(iterations=3, fix_sample_across_iterations=True)
+    samples_a = _run_and_capture_samples(config_a, out_df, tmp_path_factory.mktemp("run_a"))
+
+    config_b = _dch_config(iterations=3, fix_sample_across_iterations=True)
+    samples_b = _run_and_capture_samples(config_b, out_df, tmp_path_factory.mktemp("run_b"))
+
+    assert set(samples_a) != set(samples_b)
+
+
+def test_flag_ignored_for_non_dch_jobs(tmp_path):
+    """A stray DCH_FIX_SAMPLE_ACROSS_ITERATIONS=true on a non-DCH job must be a no-op,
+    not an attempt to build DCH abstract pools from a DataFrame that doesn't have them."""
+    config = SimpleNamespace(
+        iterations=2,
+        current_iteration=999,
+        is_dch=False,
+        is_km_with_gpt=True,
+        is_skim_with_gpt=False,
+        dch_fix_sample_across_iterations=True,
+        global_settings={},
+    )
+    out_df = pd.DataFrame({"a_term": ["A1"], "b_term": ["B1"]})
+
+    with patch("skimgpt.relevance_helper.process_single_row", lambda *_a, **_k: None), \
+         patch("skimgpt.relevance_helper.write_to_json", lambda *_a, **_k: None):
+        run_iterations(config, out_df, num_abstracts_fetched=0, output_base_dir=str(tmp_path))

--- a/tests/test_iteration_parallelism.py
+++ b/tests/test_iteration_parallelism.py
@@ -93,7 +93,7 @@ def test_run_iterations_executes_in_parallel(tmp_path, monkeypatch):
     called_iterations: list[int] = []
 
     def slow_stub(out_df, config, num_abstracts_fetched, *, output_base_dir,
-                  iteration_number):
+                  iteration_number, fixed_sample=None):
         called_iterations.append(iteration_number)
         time.sleep(sleep_s)
 


### PR DESCRIPTION
…om sampling variance

Each DCH iteration previously drew its own independent abstract sample, so scoring differences across iterations conflated two sources of variance: which 50 abstracts got sampled, and how the LLM scored a given abstract set. There was no way to hold the first constant to measure the second in isolation.

Adds an optional DCH_FIX_SAMPLE_ACROSS_ITERATIONS in GLOBAL_SETTINGS (default false, unchanged behavior). When true, run_iterations draws one sample before the iteration loop and every iteration scores that same sample via process_results(fixed_sample=...), instead of each iteration calling sample_consolidated_abstracts independently.

This is the complement to DCH_SAMPLE_SEED, not a replacement: that flag deliberately keeps iterations different from each other (reproducible per-run, varying per-iteration) since that's what iterations are for. This flag does the opposite on purpose. The two compose: when both are set, the one fixed draw goes through _dch_rng too, so it's reproducible across reruns as well as constant across iterations.

Verified against a real run (real PubMed abstracts, real OpenAI o3 DCH scoring, Triton/CHTC's classifier step stood in for since neither was available): all 3 iterations scored the identical 50 PMIDs, and the model still flipped its verdict on 3/50 abstracts across iterations on identical input, confirming the isolated signal is real LLM output variance.